### PR TITLE
Support retrieval of custom data keys from User models

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -175,6 +175,11 @@ class User implements SymfonyUserInterface, UserInterface
         return $this->data['user_metadata'][$name];
     }
 
+    public function getCustomData(string $key): mixed
+    {
+        return $this->data[$key] ?? null;
+    }
+
     public function eraseCredentials()
     {
     }


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

I've set custom data in Auth0 via Rules. Currently, it is not possible to retrieve that data from the User class. I've added a getter method to get the custom user data by key. As the content of that data is not known, we have to use mixed as the return type.
An alternative approach would be to make the current private property `data` protected, so I as a developer can extend the User class and get fetch my custom data in my own class.

### References

- https://auth0.com/docs/customize/rules

### Testing

Create a rule in Auth0, which adds some custom data to e.g. idToken or accessToken with a custom key e.g. `https://mydomain.com/custom_data`.

[x] This change has been tested on the latest version of Symfony

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
