### PR TITLE
Correct logout mistake in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ class ExampleController extends AbstractController
     public function private(): Response
     {
         return new Response(
-            '<html><body><pre>' . print_r($this->getUser(), true) . '</pre> <a href="/auth0/logout">Logout</a></body></html>'
+            '<html><body><pre>' . print_r($this->getUser(), true) . '</pre> <a href="/logout">Logout</a></body></html>'
         );
     }
 }


### PR DESCRIPTION
The route `/auth0/logout` isn't defined - the example should be just `/logout`

### Changes

Tried following the README. Auth0 threw an error when I tried to logout. 

### Testing

Follow the tutorial on a new machine.

[ ] This change adds test coverage

[x] This change has been tested on the latest version of Symfony

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
