### PR TITLE
docs: Update README to indicate supported Symfony versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@ Symfony SDK for [Auth0](https://auth0.com) Authentication and Management APIs.
 ### Requirements
 
 - [PHP](http://php.net/) 8.1+
-- [Symfony](https://symfony.com/) 6.1+
+- [Symfony](https://symfony.com/) 6.1+, <6.4
+  - Symfony 7.0 is not currently supported.
 
 > Please review our [support policy](#support-policy) to learn when language and framework versions will exit support in the future.
 


### PR DESCRIPTION
### Changes

This PR updates the README to reflect that we do not currently support Symfony 7.

### References

N/A

### Testing

N/A

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
[x] All existing and new tests complete without errors