### PR TITLE
fix: Restore method signatures

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -458,7 +458,7 @@ return static function (RectorConfig $rectorConfig): void {
         RemoveUnusedPrivateClassConstantRector::class,
         RemoveUnusedPrivateMethodParameterRector::class,
         RemoveUnusedPrivatePropertyRector::class,
-        RemoveUnusedPromotedPropertyRector::class,
+        // RemoveUnusedPromotedPropertyRector::class,
         RemoveUnusedVariableAssignRector::class,
         RemoveUnusedVariableInCatchRector::class,
         RemoveUselessReturnTagRector::class,

--- a/src/Security/Authenticator.php
+++ b/src/Security/Authenticator.php
@@ -6,6 +6,7 @@ namespace Auth0\Symfony\Security;
 
 use Auth0\Symfony\Contracts\Security\AuthenticatorInterface;
 use Auth0\Symfony\Service;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\{RedirectResponse, Request, Response};
 use Symfony\Component\Routing\RouterInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -21,6 +22,7 @@ final class Authenticator extends AbstractAuthenticator implements Authenticator
         public array $configuration,
         public Service $service,
         private RouterInterface $router,
+        private LoggerInterface $logger,
     ) {
     }
 

--- a/src/Security/Authorizer.php
+++ b/src/Security/Authorizer.php
@@ -6,6 +6,7 @@ namespace Auth0\Symfony\Security;
 
 use Auth0\Symfony\Contracts\Security\AuthorizerInterface;
 use Auth0\Symfony\Service;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\{JsonResponse, Request, Response};
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Exception\AuthenticationException;
@@ -18,6 +19,7 @@ final class Authorizer extends AbstractAuthenticator implements AuthorizerInterf
     public function __construct(
         private array $configuration,
         private Service $service,
+        private LoggerInterface $logger,
     ) {
     }
 

--- a/src/Security/UserProvider.php
+++ b/src/Security/UserProvider.php
@@ -11,11 +11,17 @@ use Auth0\Symfony\Contracts\Security\UserProviderInterface;
 use Auth0\Symfony\Models\Stateful\User as StatefulUser;
 use Auth0\Symfony\Models\Stateless\User as StatelessUser;
 use Auth0\Symfony\Models\User;
+use Auth0\Symfony\Service;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\User\{UserInterface as SymfonyUserInterface, UserProviderInterface as SymfonyUserProviderInterface};
 
 final class UserProvider implements SymfonyUserProviderInterface, UserProviderInterface
 {
+    public function __construct(
+        private Service $service,
+    ) {
+    }
+
     public function loadByUserModel(User $user): SymfonyUserInterface
     {
         return $user;

--- a/src/Service.php
+++ b/src/Service.php
@@ -8,6 +8,7 @@ use Auth0\SDK\Auth0;
 use Auth0\SDK\Configuration\SdkConfiguration;
 use Auth0\SDK\Utility\HttpTelemetry;
 use Auth0\Symfony\Contracts\ServiceInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -20,6 +21,7 @@ final class Service implements ServiceInterface
     public function __construct(
         private SdkConfiguration $configuration,
         private RequestStack $requestStack,
+        private LoggerInterface $logger,
     ) {
     }
 

--- a/src/Stores/SessionStore.php
+++ b/src/Stores/SessionStore.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Auth0\Symfony\Stores;
 
 use Auth0\SDK\Contract\StoreInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
 use Symfony\Component\HttpFoundation\{Request, RequestStack};
 use Throwable;
@@ -14,6 +15,7 @@ final class SessionStore implements StoreInterface
     public function __construct(
         private $namespace,
         private RequestStack $requestStack,
+        private LoggerInterface $logger,
     ) {
     }
 


### PR DESCRIPTION
### Changes

5.2.0 inadvertently altered some method signatures due to new code styling tooling rules; this restores those methods to their previous state, to avoid introducing breaking changes.

### References

Resolves #173 

### Testing

N/A

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)
- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)
- [x] All existing and new tests complete without errors
