### PR TITLE
Do not redeclare controller container property in order to avoid compatibility issues

### DIFF
--- a/src/Controllers/AuthenticationController.php
+++ b/src/Controllers/AuthenticationController.php
@@ -22,8 +22,9 @@ final class AuthenticationController extends AbstractController implements Authe
     public function __construct(
         private Authenticator $authenticator,
         private RouterInterface $router,
-        protected ContainerInterface $container,
+        ContainerInterface $container,
     ) {
+        $this-setContainer($container);
     }
 
     /**


### PR DESCRIPTION
### Changes

Please describe both what is changing and why this is important. Include:

- Removing scope keyword from constructor parameter to avoid property re-declaration
- In turn that allows compatibility with both symfony version 6.x and 7.x
- Using given setter to achieve the same desired result

### References

[#178]

### Testing

Previously Symfony (6.4) app container building (cache:clear) was throwing a fatal error, now it's not.

- [ ] This change adds test coverage

- [x] This change has been tested on the latest version of Symfony

### Checklist

- [x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

- [x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

- [ ] All existing and new tests complete without errors
