### PR TITLE
Fix syntax typo in AuthenticationController::__construct()

### DIFF
--- a/src/Controllers/AuthenticationController.php
+++ b/src/Controllers/AuthenticationController.php
@@ -24,7 +24,7 @@ final class AuthenticationController extends AbstractController implements Authe
         private RouterInterface $router,
         ContainerInterface $container,
     ) {
-        $this-setContainer($container);
+        $this->setContainer($container);
     }
 
     /**


### PR DESCRIPTION
### Changes

Fix syntax typo in the previous code change in `AuthenticationController::__construct()`

### References

https://github.com/auth0/symfony/issues/178
https://github.com/auth0/symfony/pull/179
https://github.com/auth0/symfony/actions/runs/7279226624/job/19835136156
https://github.com/auth0/symfony/actions/runs/7279226624/job/19835137264

### Testing

[ ] This change adds test coverage

[ ] This change has been tested on the latest version of Symfony

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[ ] All existing and new tests complete without errors
