### PR TITLE
feat: Support string concatenation of scopes

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -254,7 +254,7 @@ class User implements SymfonyUserInterface, UserInterface
         $scopes = $this->data['scope'] ?? [];
 
         if (is_string($scopes)) {
-            $scopes = [$scopes];
+            $scopes = explode(' ', $scopes);
         }
 
         foreach ($roles as $role) {

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Auth0\Tests\Unit\Models;
+
+use Auth0\Symfony\Models\User;
+use PHPUnit\Framework\TestCase;
+
+class UserTest extends TestCase
+{
+
+    /** @param string[] $expectedRoles */
+    private function assertHasRoles(User $user, array $expectedRoles): void
+    {
+        $userRoles = $user->getRoles();
+        foreach ($expectedRoles as $role) {
+            $this::assertContains($role, $userRoles);
+        }
+    }
+
+    public function testGetRolesWithSingleScope(): void
+    {
+        $user = new User([
+            'scope' => 'read:users',
+        ]);
+
+        $this->assertHasRoles($user, ['ROLE_USER', 'ROLE_READ_USERS']);
+    }
+
+    public function testGetRolesWithArrayScope(): void
+    {
+        $user = new User([
+            'scope' => ['read:users', 'write:users'],
+        ]);
+
+        $this->assertHasRoles($user, ['ROLE_USER', 'ROLE_READ_USERS', 'ROLE_WRITE_USERS']);
+    }
+
+    public function testGetRolesWithStringScope(): void
+    {
+        $user = new User([
+            'scope' => 'read:users write:users',
+        ]);
+
+        $this->assertHasRoles($user, ['ROLE_USER', 'ROLE_READ_USERS', 'ROLE_WRITE_USERS']);
+    }
+}


### PR DESCRIPTION
### Changes

There has been support for Symfony role resolution from both `permissions` and `scope` claims in the JWT tokens for a while now.

However, there was a problem that this bundle expected `scope` claim to be either an array, or a string with the single scope value, while in reality Auth0 authentication API returns tokens with `scope` value being a concatenated string of multiple scope values:

<img width="905" alt="Screenshot 2024-01-16 at 15 00 12" src="https://github.com/auth0/symfony/assets/392168/9a860d4a-938e-44d1-b105-364b31d574ad">

In this bundle such scope produced an unusable role code with spaces in it and all permissions in one string.

This PR fixes this issue, by adding support for concatenated-string scope value while preserving support for previous formats as well.

### Testing

PhpUnit tests added (both previous formats + the new one; i.e. one test would fail on old codebase)

[x] This change adds test coverage

[ ] This change has been tested on the latest version of Symfony

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
