### PR TITLE
Normalize dashes in JWT permissions/scopes

### DIFF
--- a/src/Models/User.php
+++ b/src/Models/User.php
@@ -258,13 +258,13 @@ class User implements SymfonyUserInterface, UserInterface
         }
 
         foreach ($roles as $role) {
-            $response[] = implode('_', explode(':', strtoupper($role)));
+            $response[] = str_replace([':', '-'], '_', strtoupper($role));
         }
 
         if (is_array($permissions)) {
             foreach ($permissions as $permission) {
                 if (is_string($permission)) {
-                    $response[] = 'ROLE_' . implode('_', explode(':', strtoupper($permission)));
+                    $response[] = 'ROLE_' . str_replace([':', '-'], '_', strtoupper($permission));
                 }
             }
         }
@@ -272,7 +272,7 @@ class User implements SymfonyUserInterface, UserInterface
         if (is_array($scopes)) {
             foreach ($scopes as $scope) {
                 if (is_string($scope)) {
-                    $response[] = 'ROLE_' . implode('_', explode(':', strtoupper($scope)));
+                    $response[] = 'ROLE_' . str_replace([':', '-'], '_', strtoupper($scope));
                 }
             }
         }


### PR DESCRIPTION
### Changes

When converting permissions/scopes to Symfony roles, apply replacement not only for colon (`:`) character, but also for dash (`-`) character, as some resources/permissions consist of multiple words and dash is a recommended separator in such cases.


### Testing

- Have a permission/scope in Auth0 token that contains a dash (e.g. `read:licence-plates`)
- Convert it to Symfony roles (by getting the roles of the JWT authenticated user/m2m):
    - before: it would return `ROLE_READ_LICENCE-PLATES`
    - after: it returns `ROLE_READ_LICENCE_PLATES`
   

[ ] This change adds test coverage

[ ] This change has been tested on the latest version of Symfony

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
