### PR TITLE
Allow symfony-7 in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,9 +34,9 @@
     "ext-mbstring": "*",
     "ext-openssl": "*",
     "auth0/auth0-php": "^8.10",
-    "symfony/cache": "^6.4",
-    "symfony/framework-bundle": "^6.4",
-    "symfony/security-bundle": "^6.4"
+    "symfony/cache": "^6.4 || ^7.0",
+    "symfony/framework-bundle": "^6.4 || ^7.0",
+    "symfony/security-bundle": "^6.4 || ^7.0"
   },
   "require-dev": {
     "ergebnis/composer-normalize": "^2",


### PR DESCRIPTION
### Changes

This is simply allowing Symfony 7 in composer.json - could not find any problems or incompatibilities at this point.

- composer.json updated
- all tests (`composer test`) are passing
- tried it out on a minimal Symfony 7 project - no problems found
    - though I have only verified the JWT authentication use-case

### References

#182 

### Testing

Attempted to install this bundle on a small Symfony project and perform JWT authentication. Other use-cases should be verified.

Maybe instead of merging to `main` branch, this should be "quarantined" in a dedicated branch (e.g. `symfony7`) of this main repository - that way other people would be able to install this version via composer by requiring `auth0/symfony: dev-symfony7` and then test on their applications and their use-cases?

[ ] This change adds test coverage

[x] This change has been tested on the latest version of Symfony

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
