### PR TITLE
Remove $container parameter from controller constructors

### DIFF
--- a/psalm.xml.dist
+++ b/psalm.xml.dist
@@ -24,5 +24,10 @@
         <PossiblyNullArgument errorLevel="suppress" />
         <PossiblyNullPropertyAssignmentValue errorLevel="suppress" />
         <PossiblyNullReference errorLevel="suppress" />
+        <PropertyNotSetInConstructor>
+            <errorLevel type="suppress">
+                <referencedProperty name="Symfony\Bundle\FrameworkBundle\Controller\AbstractController::$container" />    <!-- Injected by Symfony DI via setContainer() because marked as #[Required] -->
+            </errorLevel>
+        </PropertyNotSetInConstructor>
     </issueHandlers>
 </psalm>

--- a/src/Controllers/AuthenticationController.php
+++ b/src/Controllers/AuthenticationController.php
@@ -7,9 +7,7 @@ namespace Auth0\Symfony\Controllers;
 use Auth0\SDK\Auth0;
 use Auth0\Symfony\Contracts\Controllers\AuthenticationControllerInterface;
 use Auth0\Symfony\Security\Authenticator;
-use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\Exception\{BadRequestException, ConflictingHeadersException, SuspiciousOperationException};
 use Symfony\Component\HttpFoundation\{RedirectResponse, Request, Response};
 use Symfony\Component\Routing\RouterInterface;
 use Throwable;
@@ -22,9 +20,7 @@ final class AuthenticationController extends AbstractController implements Authe
     public function __construct(
         private Authenticator $authenticator,
         private RouterInterface $router,
-        ContainerInterface $container,
     ) {
-        $this->container = $container;
     }
 
     /**

--- a/src/Controllers/BackchannelLogoutController.php
+++ b/src/Controllers/BackchannelLogoutController.php
@@ -7,9 +7,8 @@ namespace Auth0\Symfony\Controllers;
 use Auth0\SDK\Auth0;
 use Auth0\Symfony\Contracts\Controllers\AuthenticationControllerInterface;
 use Auth0\Symfony\Security\Authenticator;
-use Psr\Container\ContainerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\{RedirectResponse, Request, Response};
+use Symfony\Component\HttpFoundation\{Request, Response};
 use Throwable;
 
 use function is_string;
@@ -18,9 +17,7 @@ final class BackchannelLogoutController extends AbstractController implements Au
 {
     public function __construct(
         private Authenticator $authenticator,
-        ContainerInterface $container,
     ) {
-        $this->container = $container;
     }
 
     /**


### PR DESCRIPTION
### Changes

Fix for issue #189

- Removed `$container` parameter from controllers (because it is injected via `setContainer()` by Symfony DI)
- Added exception in psalm config not to report this as a problem

### References

#189

### Testing

Tested statically and on a Symfony 7.0 project (although controllers are not executed there - verified that container builds without problems and `bin/console list:container` reports no problems)

Tested only statically on Symfony 6.4.

Testing on older Symfony versions would be much appreciated.

[ ] This change adds test coverage

[x] This change has been tested on the latest version of Symfony

### Checklist

[x] I have read the [Auth0 general contribution guidelines](https://github.com/auth0/open-source-template/blob/master/GENERAL-CONTRIBUTING.md)

[x] I have read the [Auth0 Code of Conduct](https://github.com/auth0/open-source-template/blob/master/CODE-OF-CONDUCT.md)

[x] All existing and new tests complete without errors
